### PR TITLE
fix SSL3_GET_SERVER_CERTIFICATE verify failed

### DIFF
--- a/cloudxns/api.py
+++ b/cloudxns/api.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 __API_URL__ = 'https://www.cloudxns.net/api2/'
-
+__httplib_params__ = {'disable_ssl_certificate_validation':True}
 
 class Api:
     def __init__(self, api_key=None, secret_key=None):
@@ -69,18 +69,18 @@ class Api:
 
         if self.__debug:
             resp, content = eval(method)(__API_URL__ + uri,
-                                                params=data, headers=self.__headers, resp=self.__debug, async=False)
+                                                params=data, headers=self.__headers, resp=self.__debug, async=False,httplib_params=__httplib_params__)
             return resp, content
 
         else:
             content = eval(method)(__API_URL__ + uri,
-                                          params=data, headers=self.__headers, resp=self.__debug, async=False)
+                                          params=data, headers=self.__headers, resp=self.__debug, async=False,httplib_params=__httplib_params__)
 
             return content
 
     @staticmethod
     def vsersion():
-        return GET(__API_URL__ + 'version')
+        return GET(__API_URL__ + 'version',httplib_params=__httplib_params__)
 
     def domain_list(self):
         """


### PR DESCRIPTION
httplib2.SSLHandshakeError: [Errno 1] _ssl.c:504: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
httplib2 模块，默认disable_ssl_certificate_validation=False，会开启SSL验证，导致失败，是调用resetclient的方法时，传入参数将disable_ssl_certificate_validation=True，跳过SSl验证
